### PR TITLE
Clouds API

### DIFF
--- a/src/clouds.ts
+++ b/src/clouds.ts
@@ -1,0 +1,20 @@
+export interface AzureCloudInfo {
+  name: string;
+  displayName: string;
+}
+
+const predefinedClouds: AzureCloudInfo[] = [
+  {
+    name: 'AzureCloud', displayName: 'Azure'
+  },
+  {
+    name: 'AzureChinaCloud', displayName: 'Azure China'
+  },
+  {
+    name: 'AzureUSGovernment', displayName: 'Azure US Government'
+  }
+];
+
+export function getAzureClouds(): AzureCloudInfo[] {
+  return predefinedClouds;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './AzureCredentials';
+export * from './clouds';


### PR DESCRIPTION
Introduces a function which returns a list of clouds for front end: `getAzureClouds()`.

```ts
import { getAzureClouds } from '@grafana/azure-sdk';

const clouds = useMemo(() => {
  return getAzureClouds().map<SelectableValue>(c => {
    return { value: c.name, label: c.displayName }
  });
}, []);
```

This will allow to remove hardcoded lists of clouds from datasources.

Usage example https://github.com/grafana/azure-data-explorer-datasource/pull/800