### PR TITLE
List of Azure clouds from Grafana backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.vscode/
+.idea/
+
 node_modules/
 coverage/
 ci/
@@ -5,5 +8,6 @@ cypress/report.json
 cypress/screenshots/actual
 cypress/videos/
 dist/
-yarn-error.log
 compiled/
+.eslintcache
+yarn-error.log

--- a/src/clouds.ts
+++ b/src/clouds.ts
@@ -1,5 +1,7 @@
 import { AzureSettings, config } from '@grafana/runtime';
 
+// TODO: Remove when the list of clouds added directly to @grafana/runtime
+//  https://github.com/grafana/grafana/pull/84039
 interface AzureSettings2 extends AzureSettings {
   clouds?: AzureCloudInfo[];
 }

--- a/src/clouds.ts
+++ b/src/clouds.ts
@@ -1,3 +1,9 @@
+import { AzureSettings, config } from '@grafana/runtime';
+
+interface AzureSettings2 extends AzureSettings {
+  clouds?: AzureCloudInfo[];
+}
+
 export interface AzureCloudInfo {
   name: string;
   displayName: string;
@@ -16,5 +22,12 @@ const predefinedClouds: AzureCloudInfo[] = [
 ];
 
 export function getAzureClouds(): AzureCloudInfo[] {
+  const settingsEx = (config.azure as unknown as AzureSettings2);
+
+  // Return list of clouds from Grafana configuration if they are provided
+  if (Array.isArray(settingsEx.clouds)) {
+    return settingsEx.clouds;
+  }
+
   return predefinedClouds;
 }


### PR DESCRIPTION
This PR allows to optionally pass a list of clouds from Grafana backend, allowing to customize the list when necessary.
If custom list of clouds is not passed, then use the predefined list of public clouds.

Passing list of clouds on the Grafana side: https://github.com/grafana/grafana/pull/83460