### PR TITLE
Fix logic around selecting custom vs predefined cloud list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/azure-sdk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Common Azure features for Grafana",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",

--- a/src/clouds.ts
+++ b/src/clouds.ts
@@ -19,7 +19,7 @@ export function getAzureClouds(): AzureCloudInfo[] {
   const settingsEx = config.azure;
 
   // Return list of clouds from Grafana configuration if they are provided
-  if (Array.isArray(settingsEx.clouds)) {
+  if (Array.isArray(settingsEx.clouds) && settingsEx.clouds.length > 0) {
     return settingsEx.clouds;
   }
 


### PR DESCRIPTION
The current logic doesn't account for an empty array, in which case we should be returning the predefined clouds instead of an empty list