### PR TITLE
Add additional credential types and methods

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -5,6 +5,9 @@
     "currentuser",
     "typecheck",
     "workloadidentity",
-    "datasource"
+    "datasource",
+    "azuremonitor",
+    "chinaazuremonitor",
+    "govazuremonitor"
   ]
 }

--- a/src/clouds.ts
+++ b/src/clouds.ts
@@ -36,3 +36,21 @@ export function getAzureClouds(): AzureCloudInfo[] {
 export function getDefaultAzureCloud(): string {
   return config.azure.cloud || AzureCloud.Public;
 }
+
+export function resolveLegacyCloudName(cloudName: string | undefined): string | undefined {
+  if (!cloudName) {
+    // if undefined, allow the code to fallback to calling getDefaultAzureCloud() since that has the complete logic for handling an empty cloud name
+    return undefined;
+  }
+
+  switch (cloudName) {
+    case 'azuremonitor':
+      return AzureCloud.Public;
+    case 'chinaazuremonitor':
+      return AzureCloud.China;
+    case 'govazuremonitor':
+      return AzureCloud.USGovernment;
+    default:
+      throw new Error(`Azure cloud '${cloudName}' is not recognized by datasource.`);
+  }
+}

--- a/src/credentials/AzureCredentials.ts
+++ b/src/credentials/AzureCredentials.ts
@@ -1,4 +1,4 @@
-export type AzureAuthType = 'currentuser' | 'msi' | 'workloadidentity' | 'clientsecret' | 'clientsecret-obo';
+export type AzureAuthType = 'currentuser' | 'msi' | 'workloadidentity' | 'clientsecret' | 'clientsecret-obo' | 'currentuser' | 'ad-password';
 
 export type ConcealedSecret = symbol;
 
@@ -39,12 +39,20 @@ export interface AzureClientSecretOboCredentials extends AzureCredentialsBase {
   clientSecret?: string | ConcealedSecret;
 }
 
+export interface AzureAdPasswordCredentials extends AzureCredentialsBase {
+  authType: 'ad-password';
+  userId?: string;
+  clientId?: string;
+  password?: string | ConcealedSecret;
+}
+
 export type AzureCredentials =
   | AadCurrentUserCredentials
   | AzureManagedIdentityCredentials
   | AzureWorkloadIdentityCredentials
   | AzureClientSecretCredentials
-  | AzureClientSecretOboCredentials;
+  | AzureClientSecretOboCredentials
+  | AzureAdPasswordCredentials;
 
 export function instanceOfAzureCredential<T extends AzureCredentials>(
   authType: AzureAuthType,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@ import { AzureAuthType, AzureCredentials } from './credentials/AzureCredentials'
 export interface AzureDataSourceJsonData extends DataSourceJsonData {
   // Azure credentials
   azureCredentials?: AzureCredentials;
+  oauthPassThru?: boolean;
 
   // Legacy Azure credentials
   cloudName?: string;
@@ -15,6 +16,7 @@ export interface AzureDataSourceJsonData extends DataSourceJsonData {
 
 export interface AzureDataSourceSecureJsonData {
   azureClientSecret?: string;
+  password?: string;
 
   // Legacy Azure credentials
   clientSecret?: string;


### PR DESCRIPTION
Changes in this PR:
1. Add `clientsecret-obo`, `ad-password` auth as well as additional shared helper methods. This covers all the existing azure credential types currently supported by azure datasources.
2. Add checking for the feature flags for user identity
3. For obo, Add `oboEnabled` parameter to get/updateDatasourceCredentials, because obo is only supported by adx and under a adx-specific feature flag (`adxOnBehalfOf`). We can update it later if we choose to move this to azure config.