### PR TITLE
chore: use shared data-sources Renovate base preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,45 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>grafana/grafana-renovate-config//presets/automerge"],
-  "platformAutomerge": true,
-  "packageRules": [
-    {
-      "description": "Disable minimum release age for Grafana owned npm packages (@grafana/*)",
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["@grafana/*"],
-      "minimumReleaseAge": null
-    },
-    {
-      "description": "Disable minimum release age for Grafana owned GitHub Actions (grafana/*)",
-      "matchManagers": ["github-actions"],
-      "matchPackageNames": ["grafana/*"],
-      "minimumReleaseAge": null
-    },
-    {
-      "description": "Ignore major updates for dependencies that need to be kept in sync with Grafana",
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["react", "react-dom", "react-router-dom", "react-router-dom-v5-compat"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
-    },
-    {
-      "description": "Ignore major updates for dependencies that need to be kept in sync with the Node version defined in .nvmrc",
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["@types/node"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
-    },
-    {
-      "description": "Keep rxjs in sync with the version used by @grafana/* packages",
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["rxjs"],
-      "enabled": false
-    },
-    {
-      "description": "Automerge minor dependencies",
-      "matchUpdateTypes": ["minor"],
-      "automerge": true,
-      "labels": ["automerge-minor"]
-    }
-  ]
+  "extends": ["github>grafana/grafana-renovate-config//presets/data-sources/base"]
 }


### PR DESCRIPTION
## Summary

Adopt the shared data-sources Renovate base preset so dependency updates are batched and handled consistently across the fleet.

## Changes

- Replace this repo's Renovate config with a one-line extends of `github>grafana/grafana-renovate-config//presets/data-sources/base`.

The shared preset batches non-major updates into one PR per ecosystem (Frontend / Backend / Docker / GitHub Actions), applies a 3-day release-age soak (Grafana-owned dependencies exempt), pins npm ranges to exact versions, keeps React/Node/rxjs in sync with Grafana, and automerges minor devDependencies while leaving production dependencies for review.