### PR TITLE
ci: use shared reusable stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,13 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions: {}
+
+jobs:
+  stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: grafana/data-sources-ci-workflows/.github/workflows/reusable-stale.yml@main # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Adds a stale workflow using the shared reusable workflow from `grafana/data-sources-ci-workflows`.